### PR TITLE
Multithread the CspExamples repo!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ os:
   - linux
 
 julia:
-  - 1.0
+  - 1.1
   - nightly
+
+env:
+  - JULIA_NUM_THREADS=1
+  - JULIA_NUM_THREADS=4
 
 notifications:
   email: false

--- a/test/CspExamples.jl
+++ b/test/CspExamples.jl
@@ -8,16 +8,15 @@ end
 @testset "S31_COPY" begin
     @testset "Copy pre-filled buffer" begin
         # The input channel is a 1-character buffer as described in the paper.
-        west = Channel(ch->(fill_channel(ch, "hello")), csize=1, ctype=Char)
-        east = Channel(ch->CspExamples.S31_COPY(west, ch), ctype=Char)
+        west = Channel(ch->(fill_channel(ch, "hello")), csize=1, ctype=Char, sticky=false)
+        east = Channel(ch->CspExamples.S31_COPY(west, ch), ctype=Char, sticky=false)
         @test String(collect(east)) == "hello"
     end
     @testset "test incremental concurrent copying" begin
+        # TODO: Should these be unbuffered channels?
         west = Channel{Char}(1)
-        east = Channel(ch->CspExamples.S31_COPY(west, ch), ctype=Char, csize=Inf)
-        put!(west, 'w');
-        @test (yield(); isready(east))  # Need to yield before testing concurrent behavior
-        put!(west, 'o'); put!(west, 'r'); put!(west, 'l'); put!(west, 'd');
+        east = Channel(ch->CspExamples.S31_COPY(west, ch), ctype=Char, csize=Inf, sticky=false)
+        put!(west, 'w'); put!(west, 'o'); put!(west, 'r'); put!(west, 'l'); put!(west, 'd');
         close(west)
         @test String(collect(east)) == "world"
     end
@@ -25,42 +24,42 @@ end
 
 @testset "S32_SQUASH" begin
     # The input channel is a 1-character buffer as described in the paper.
-    west = Channel(csize=1, ctype=Char) do ch
+    west = Channel(csize=1, ctype=Char, sticky=false) do ch
         fill_channel(ch, "hello*to**the*world")
     end
-    east = Channel(ch->CspExamples.S32_SQUASH(west, ch), ctype=Char)
+    east = Channel(ch->CspExamples.S32_SQUASH(west, ch), ctype=Char, sticky=false)
     @test String(collect(east)) == "hello*to↑the*world"
 end
 
 # Convenience function to create and fill a channel.
-make_fill_close_chnl(input; csize=0, ctype=eltype(input)) = Channel(csize=csize, ctype=ctype) do ch
+make_fill_close_chnl(input; csize=0, ctype=eltype(input)) = Channel(csize=csize, ctype=ctype, sticky=false) do ch
     fill_channel(ch, input)
 end
 
 @testset "S32_SQUASH_EXT" begin
     # Test 1 * at end
     west = make_fill_close_chnl("hello**world*")
-    east = Channel(ch->CspExamples.S32_SQUASH_EXT(west, ch), ctype=Char)
+    east = Channel(ch->CspExamples.S32_SQUASH_EXT(west, ch), ctype=Char, sticky=false)
     @test String(collect(east)) == "hello↑world*"
 
     # Test 3 *s at end
     west = make_fill_close_chnl("hello**world***", csize=1)
-    east = Channel(ch->CspExamples.S32_SQUASH_EXT(west, ch), ctype=Char)
+    east = Channel(ch->CspExamples.S32_SQUASH_EXT(west, ch), ctype=Char, sticky=false)
     @test String(collect(east)) == "hello↑world↑*"
 end
 
 @testset "S33_DISASSEMBLE" begin
-    cardfile = Channel(ctype=String) do ch
+    cardfile = Channel(ctype=String, sticky=false) do ch
         for s in ["hey", "buddy"]; put!(ch, s); end
     end
     @test "hey buddy " ==
-            String(collect(Channel(X->CspExamples.S33_DISASSEMBLE(cardfile, X), ctype=Char)))
+            String(collect(Channel(X->CspExamples.S33_DISASSEMBLE(cardfile, X), ctype=Char, sticky=false)))
 end
 
 @testset "S34_ASSEMBLE" begin
     linelength = 3
     inputstr = rand('a':'z', linelength*2)
-    X = Channel(ctype=Char) do ch
+    X = Channel(ctype=Char, sticky=false) do ch
         # Pass two characters too few.
         for s in inputstr[1:end-2]; put!(ch, s); end
     end
@@ -76,13 +75,13 @@ end
 end
 
 @testset "S35_Reformat" begin
-    reformatted = Channel() do ch
+    reformatted = Channel(sticky=false) do ch
         CspExamples.S35_Reformat(make_fill_close_chnl(["hello", "world"]), ch, 4)
     end
     @test collect(reformatted) == ["hell", "o wo", "rld "]
 end
 @testset "S35_Reformat2" begin
-    reformatted = Channel() do ch
+    reformatted = Channel(sticky=false) do ch
         CspExamples.S35_Reformat2(make_fill_close_chnl(["hello", "world"]), ch, 4)
     end
     @test collect(reformatted) == ["hell", "o wo", "rld "]
@@ -99,7 +98,7 @@ end
 end
 
 @testset "S36_Conway" begin
-    reformatted = Channel() do ch
+    reformatted = Channel(sticky=false) do ch
         CspExamples.S36_Conway(make_fill_close_chnl(["**hello", "world**"]), ch, 4)
     end
     @test collect(reformatted) == ["↑hel", "lo w", "orld", "↑   "]


### PR DESCRIPTION
Enable multithreading for the CspExamples repo:

Schedule all our Tasks with the multithreading scheduler (`sticky=false`) in CspExamples, and configure travis to run once with NUM_THREADS=1 and once with NUM_THREADS=4.


It's cool, because I didn't have to change any of the implementations at all, which is the point that's always emphasized by proponents of this CSP / coroutines+channels architecture: _The code structure doesn't need to change at all to scale your parallelism. You just change the number of threads you're scheduling on, and that's it!_

(This includes a VERSION check to only create the tasks with `sticky=false` if `VERSION >= v"1.3.0-DEV.554"` to make sure we have the fix to Channels in https://github.com/JuliaLang/julia/issues/32575.)